### PR TITLE
Simplify Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,79 +5,56 @@
 #######
 ## Similarly, it seems that -ftree-vectorize is not obviously useful.
 ######
-FLAGS=$(CFLAGS) -O3 -std=c99 -Wall -Wextra -pedantic -I./include
+CFLAGS	+= -O3 -std=c99 -Wall -Wextra -pedantic -Iinclude
 #FLAGS+=-march=native
-FLAGS+=-march=cannonlake
+CFLAGS	+= -march=cannonlake
 
-BASE64=obj/chromiumbase64.o\
-       obj/fastavxbase64.o\
-       obj/encode_base64_avx512vbmi.o\
-       obj/decode_base64_avx512vbmi.o\
-       obj/encode_base64_avx512vl.o\
-       obj/decode_base64_avx512vbmi_despace.o\
-       obj/decode_base64_avx512vbmi__unrolled.o
+BASE64 	= src/base64/chromiumbase64.o \
+	  src/base64/fastavxbase64.o \
+	  src/base64/encode_base64_avx512vbmi.o \
+	  src/base64/decode_base64_avx512vbmi.o \
+	  src/base64/encode_base64_avx512vl.o \
+	  src/base64/decode_base64_avx512vbmi_despace.o \
+	  src/base64/decode_base64_avx512vbmi__unrolled.o
+HELPERS = src/load_file.o
+BINOBJS	= src/unit.o \
+	  src/unit_tail.o \
+	  src/unit_despace.o \
+	  src/benchmark.o \
+	  src/benchmark_despace.o \
+	  src/benchmark_email.o
 
-HELPERS=obj/load_file.o
+BINS	= unit \
+	  unit_despace \
+	  benchmark \
+	  benchmark_email \
+	  benchmark_despace
 
-ALL=$(BASE64)\
-    unit\
-    unit_despace\
-    benchmark\
-    benchmark_email\
-    benchmark_despace
+all: $(BINS)
 
-# ------------------------------------------------------------
+src/base64/chromiumbase64.o: include/chromiumbase64.h
+src/base64/decode_base64_avx512vbmi_despace.o: include/decode_base64_avx512vbmi_despace.h
+src/base64/decode_base64_avx512vbmi.o: include/decode_base64_avx512vbmi.h
+src/base64/decode_base64_avx512vbmi__unrolled.o: include/decode_base64_avx512vbmi__unrolled.h
+src/base64/encode_base64_avx512vbmi.o: include/encode_base64_avx512vbmi.h
+src/base64/encode_base64_avx512vl.o: include/encode_base64_avx512vl.h
+src/base64/fastavxbase64.o: include/fastavxbase64.h
+src/load_file.o: include/load_file.h include/memalloc.h
+src/benchmark.o: src/benchmark.h include/memalloc.h include/avx512memcpy.h
+src/benchmark_email.o: include/memalloc.h
+src/unit_tail.o: src/base64/decode_base64_tail_avx512vbmi.c
 
-all: $(ALL)
+benchmark: src/benchmark.o $(BASE64) $(HELPERS)
+benchmark_despace: src/benchmark_despace.o $(BASE64)
+benchmark_email: src/benchmark_email.o $(BASE64) $(HELPERS)
+unit: src/unit.o $(BASE64)
+unit_despace: src/unit_despace.o $(BASE64)
+unit_tail: src/unit_tail.o \
+	src/base64/chromiumbase64.o
 
-obj/chromiumbase64.o: src/base64/chromiumbase64.c include/chromiumbase64.h
-	$(CC) $(FLAGS) $< -c -o $@
-
-obj/fastavxbase64.o: src/base64/fastavxbase64.c include/fastavxbase64.h
-	$(CC) $(FLAGS) $< -c -o $@
-
-obj/encode_base64_avx512vbmi.o: src/base64/encode_base64_avx512vbmi.c include/encode_base64_avx512vbmi.h
-	$(CC) $(FLAGS) $< -c -o $@
-
-obj/encode_base64_avx512vl.o: src/base64/encode_base64_avx512vl.c include/encode_base64_avx512vl.h
-	$(CC) $(FLAGS) $< -c -o $@
-
-obj/decode_base64_avx512vbmi.o: src/base64/decode_base64_avx512vbmi.c include/decode_base64_avx512vbmi.h
-	$(CC) $(FLAGS) $< -c -o $@
-
-obj/decode_base64_avx512vbmi__unrolled.o: src/base64/decode_base64_avx512vbmi__unrolled.c include/decode_base64_avx512vbmi__unrolled.h
-	$(CC) $(FLAGS) $< -c -o $@
-
-obj/decode_base64_avx512vbmi_despace.o: src/base64/decode_base64_avx512vbmi_despace.c include/decode_base64_avx512vbmi_despace.h
-	$(CC) $(FLAGS) $< -c -o $@
-
-# ------------------------------------------------------------
-
-obj/load_file.o: src/load_file.c include/load_file.h
-	$(CC) $(FLAGS) $< -c -o $@
-
-# ------------------------------------------------------------
-
-unit: src/unit.c $(BASE64)
-	$(CC) $(FLAGS) $< $(BASE64) -o $@
-
-unit_tail: src/unit_tail.c src/base64/decode_base64_tail_avx512vbmi.c obj/chromiumbase64.o
-	$(CC) $(FLAGS) $< obj/chromiumbase64.o -o $@
-
-unit_despace: src/unit_despace.c $(BASE64)
-	$(CC) $(FLAGS) $< $(BASE64) -o $@
-
-benchmark: src/benchmark.c src/benchmark.h $(BASE64) $(HELPERS)
-	$(CC) $(FLAGS) $< $(BASE64) $(HELPERS) -o $@
-
-benchmark_despace: src/benchmark_despace.c src/benchmark.h $(BASE64)
-	$(CC) $(FLAGS) $< $(BASE64) -o $@
-
-benchmark_email: src/benchmark_email.c src/benchmark.h $(BASE64) $(HELPERS)
-	$(CC) $(FLAGS) $< $(BASE64) $(HELPERS) -o $@
-
-# ------------------------------------------------------------
+$(BINS) unit_tail:
+	$(CC) $^ -o $@
 
 clean:
-	$(RM) $(ALL)
-
+	$(RM) $(BINS)
+	$(RM) $(BASE64) $(HELPERS) $(BINOBJS)


### PR DESCRIPTION
There's a lot to explain here, so let's start from the top.

```make
CFLAGS	+= -O3 -std=c99 -Wall -Wextra -pedantic -Iinclude
CFLAGS	+= -march=cannonlake
```

Since `make` picks up the CFLAGS from the environment, we can append our flags to it.

```make
BINOBJS = …

BINS = …

all: $(BINS)
```

Here we define the object files that make up our binaries, and the binaries themselves. This is needed for the `clean` target to make sure all object files are removed.

```make
src/base64/chromiumbase64.o: include/chromiumbase64.h
src/base64/decode_base64_avx512vbmi_despace.o: include/decode_base64_avx512vbmi_despace.h
…
```

This is basically the same rules as before, minus the call to `$(CC)`. I added some extra targets to the object files by checking the source code.

```make
benchmark: src/benchmark.o $(BASE64) $(HELPERS)
benchmark_despace: src/benchmark_despace.o $(BASE64)
…
```

Same as before, except we assign object files to the specific binaries.

```make
$(BINS) unit_tail:
	$(CC) $^ -o $@
```

Compile the binaries using the prerequisites listed above. The `$^` variable is an [automatic variable](https://www.gnu.org/software/make/manual/html_node/Automatic-Variables.html) referring to a list of all prerequisite objects for the target. This is done for each binary.

Note that `make` has builtin rules to generate `.o` files. You can check it's rule database with `make -p`. Thus we don't need to define how to make them ourselves.